### PR TITLE
fix: managerCanOverrideDuration default to false

### DIFF
--- a/Sync-AD-Groups-To-Products.ps1
+++ b/Sync-AD-Groups-To-Products.ps1
@@ -910,7 +910,7 @@ try {
             
             # Time Limit
             hasTimeLimit               = $false
-            managerCanOverrideDuration = $true
+            managerCanOverrideDuration = $false
             limitType                  = "Maximum"
             ownershipMaxDuration       = 3650
         }


### PR DESCRIPTION
managerCanOverrideDuration default to false in order to prevent updates while hastimelimit has been set to false